### PR TITLE
Fixed the scripts so that they use the correct version of python, for…

### DIFF
--- a/inject_templeos.py
+++ b/inject_templeos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 

--- a/make-dist.py
+++ b/make-dist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 Build a distribution ISO.

--- a/mfa.py
+++ b/mfa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 mfa - minimalist file access for TempleOS

--- a/snail.py
+++ b/snail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 


### PR DESCRIPTION
Fixed the scripts so that they use the correct version of python, for people with both python2 and python3

Basically the shebang env calls python2 instead of the inconsistent symlink "python".
Python2 and python3 are a little bit different. For instance "raw_input" is renamed to "input" in python3.

Alternativly, I could just port the scripts to python3, but I don't know if you'd want that. We'd still have to change `#!/usr/bin/env python` into `#!/usr/bin/env python3` to remove the inconsistency tho.
-- tyre