### PR TITLE
Change package mirror to one that is live

### DIFF
--- a/Pkg/Pkg.HC
+++ b/Pkg/Pkg.HC
@@ -11,7 +11,7 @@
 
 #define PKG_VERSION     11
 
-static U8* PKG_BASE_URL =     "http://shrineupd.clanweb.eu/packages";
+static U8* PKG_BASE_URL =     "http://shrine.lanceward.net/packages";
 static U8* PKG_LOCAL_REPO =   "::/Misc/Packages";
 static U8* PKG_TMP_DIR =      "::/Tmp/PkgTmp";
 


### PR DESCRIPTION
I am able to download packages now. I've hosted them here: 
http://shrine.lanceward.net/packages

I'll store the files so people can add more here:
https://github.com/tosrevive/ShrinePackages/

It seems like many have a maximum version due to things which have been removed from TempleOS like Bitmap support.  I see you've already got Issues for these.  Do you think it is best to add them back to the base OS or add them into the application packages?