### PR TITLE
added .gitattributes for HolyC detection by github-linguist 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.HC linguist-language=HolyC


### PR DESCRIPTION
I couldn't help but notice that linguist incorrectly classifies most of this repository as being C and C++ code,
![image](https://user-images.githubusercontent.com/43485956/93659786-1020d380-fa17-11ea-9212-17f8eaefa6f3.png)

I saw issue #46 mentioned this problem, and it was brought up that this incorrect classification is due to the line `// vim: set ft=c:` at the start of .HC files. While removing this might fix the issue, it would also remove C highlighting from vim which is undesirable. 

Rather, I wanted to test if adding a .gitattributes with `*.HC linguist-language=HolyC` would override the detection done by `// vim: set ft=c:`. Sure enough it does, and the repository can be classed as a HolyC repository without the need to remove `// vim: set ft=c:`.

![image](https://user-images.githubusercontent.com/43485956/93659963-6f331800-fa18-11ea-9636-986f8041e2a2.png)
![image](https://user-images.githubusercontent.com/43485956/93659975-7c500700-fa18-11ea-9ad8-05277e774b4b.png)

